### PR TITLE
Laravel 12 compatibility

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,9 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [9.*, 10.*, 11.*]
+        laravel: [9.*, 10.*, 11.*, 12.*]
         exclude:
           - laravel: 11.*
+            php: 8.1
+          - laravel: 12.*
             php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
     "require": {
         "php": "^8.1",
         "astrotomic/php-conditional-proxy": "^0.2.1",
-        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0",
-        "illuminate/http": "^9.0 || ^10.0 || ^11.0",
-        "illuminate/support": "^9.0 || ^10.0 || ^11.0"
+        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "illuminate/http": "^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "illuminate/support": "^9.0 || ^10.0 || ^11.0 || ^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^7.0 || ^8.0 || ^9.0",
-        "phpunit/phpunit": "^9.3 || ^10.0",
+        "orchestra/testbench": "^7.0 || ^8.0 || ^9.0 || ^10.0",
+        "phpunit/phpunit": "^9.3 || ^10.0 || ^11.5.3",
         "spatie/phpunit-snapshot-assertions": "^4.2 || ^5.1"
     },
     "prefer-stable": true,


### PR DESCRIPTION
Adds the Dependencies required to allow the Package to be used with Laravel 12.
Also adds Laravel 12 to the test matrix in the CI.

Pint/phpcs is currently failing due to changes to the Laravel Style rules. I'll supply a separate PR for these changes since I don't know if they are wanted. (#24)
