### PR TITLE
Add EditorConfig for yml files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,8 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.yml]
+indent_size = 2
+
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
When editing the Workflow Files, I noticed the missing EditorConfig definitions for yml files, as my editor formatted everything to 4 Spaces.

This PR adds a definition for yml files, which sets the indentation to 2 spaces.
