### PR TITLE
Restrict GitHub Actions permissions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,6 +3,9 @@ name: phpunit
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -3,6 +3,9 @@ name: pint
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   phpcs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- declare explicit read-only `contents` permissions for the Pint workflow
- declare explicit read-only `contents` permissions for the PHPUnit workflow

## Why

The workflows previously relied on GitHub's default `GITHUB_TOKEN` permissions. Declaring the minimum required permission satisfies the security advisory and prevents either workflow from receiving broader repository access through repository-level defaults.

There is no application runtime impact; checkout and CI behavior remain unchanged.

## Validation

- parsed both workflow files as YAML
- ran `git diff --check`
